### PR TITLE
feat: create payment via epay API

### DIFF
--- a/resources/views/tabler/gateway/epay.tpl
+++ b/resources/views/tabler/gateway/epay.tpl
@@ -3,9 +3,7 @@
         EPay 在线充值
     </h4>
     <p class="card-heading"></p>
-    <form class="epay" name="epay" action="/user/payment/purchase/epay" method="post">
-        <input hidden id="price" name="price" value="{$invoice->price}">
-        <input hidden id="invoice_id" name="invoice_id" value="{$invoice->id}">
+    <form class="epay" name="epay" method="post">
         {if $public_setting['epay_alipay']}
             <button class="btn btn-flat waves-attach" id="btnSubmit" type="submit" name="type" value="alipay">
                 <img src="/images/alipay.png" height="50px"/>
@@ -28,3 +26,53 @@
         {/if}
     </form>
 </div>
+<div class="modal modal-blur fade" id="processing-dialog" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-status bg-primary"></div>
+            <div class="modal-body text-center py-4">
+                <i class="ti ti-loader icon mb-2 text-primary icon-lg" style="font-size:3.5rem;"></i>
+                <p id="processing-message" class="text-secondary">
+                    <i class="fas fa-spinner fa-spin"></i> 正在处理你的请求，请稍候...
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    $(document).ready(function () {
+        $('.epay').on('submit', function (e) {
+            e.preventDefault();
+            $('#processing-dialog').modal('show');
+            var formData = {
+                price: {$invoice->price},
+                invoice_id: {$invoice->id},
+                type: $('button[name="type"]:focus').val()
+            };
+
+            $.ajax({
+                url: '/user/payment/purchase/epay',
+                type: 'POST',
+                data: formData,
+                dataType: "json",
+                success: function (data) {
+                    if (data.ret === 1) {
+                        $('#success-message').text(data.msg);
+                        $('#success-dialog').modal('show');
+                        window.location.href = data.url;
+                    } else {
+                        $('#fail-message').text(data.msg);
+                        $('#fail-dialog').modal('show');
+                    }
+                },
+                error: function (data) {
+                    $('#fail-message').text(data.msg);
+                    $('#fail-dialog').modal('show');
+                },
+                complete: function () {
+                    $('#processing-dialog').modal('hide');
+                }
+            });
+        });
+    });
+</script>

--- a/resources/views/tabler/gateway/epay.tpl
+++ b/resources/views/tabler/gateway/epay.tpl
@@ -1,78 +1,52 @@
 <div class="card-inner">
     <h4>
-        EPay 在线充值
+        EPay
     </h4>
     <p class="card-heading"></p>
     <form class="epay" name="epay" method="post">
         {if $public_setting['epay_alipay']}
-            <button class="btn btn-flat waves-attach" id="btnSubmit" type="submit" name="type" value="alipay">
-                <img src="/images/alipay.png" height="50px"/>
-            </button>
+        <button class="btn btn-flat waves-attach"
+                hx-post="/user/payment/purchase/epay" hx-swap="none"
+                hx-vals='js:{
+                    price: {$invoice->price},
+                    invoice_id: {$invoice->id},
+                    type: "alipay"
+                }'>
+            <img src="/images/alipay.png" height="50px"/>
+        </button>
         {/if}
         {if $public_setting['epay_wechat']}
-            <button class="btn btn-flat waves-attach" id="btnSubmit" type="submit" name="type" value="wxpay">
-                <img src="/images/wechat.png" height="50px"/>
-            </button>
+        <button class="btn btn-flat waves-attach"
+                hx-post="/user/payment/purchase/epay" hx-swap="none"
+                hx-vals='js:{
+                    price: {$invoice->price},
+                    invoice_id: {$invoice->id},
+                    type: "wxpay"
+                }'>
+            <img src="/images/wechat.png" height="50px"/>
+        </button>
         {/if}
         {if $public_setting['epay_qq']}
-            <button class="btn btn-flat waves-attach" id="btnSubmit" type="submit" name="type" value="qqpay">
-                <img src="/images/qqpay.png" height="50px"/>
-            </button>
+        <button class="btn btn-flat waves-attach"
+                hx-post="/user/payment/purchase/epay" hx-swap="none"
+                hx-vals='js:{
+                    price: {$invoice->price},
+                    invoice_id: {$invoice->id},
+                    type: "qqpay"
+                }'>
+            <img src="/images/qqpay.png" height="50px"/>
+        </button>
         {/if}
         {if $public_setting['epay_usdt']}
-            <button class="btn btn-flat waves-attach" id="btnSubmit" type="submit" name="type" value="usdt">
-                <img src="/images/usdt.png" height="50px"/>
-            </button>
+        <button class="btn btn-flat waves-attach"
+                hx-post="/user/payment/purchase/epay" hx-swap="none"
+                hx-vals='js:{
+                    price: {$invoice->price},
+                    invoice_id: {$invoice->id},
+                    type: "usdt"
+                }'>
+            <img src="/images/usdt.png" height="50px"/>
+        </button>
         {/if}
     </form>
 </div>
-<div class="modal modal-blur fade" id="processing-dialog" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
-        <div class="modal-content">
-            <div class="modal-status bg-primary"></div>
-            <div class="modal-body text-center py-4">
-                <i class="ti ti-loader icon mb-2 text-primary icon-lg" style="font-size:3.5rem;"></i>
-                <p id="processing-message" class="text-secondary">
-                    <i class="fas fa-spinner fa-spin"></i> 正在处理你的请求，请稍候...
-                </p>
-            </div>
-        </div>
-    </div>
-</div>
-<script>
-    $(document).ready(function () {
-        $('.epay').on('submit', function (e) {
-            e.preventDefault();
-            $('#processing-dialog').modal('show');
-            var formData = {
-                price: {$invoice->price},
-                invoice_id: {$invoice->id},
-                type: $('button[name="type"]:focus').val()
-            };
-
-            $.ajax({
-                url: '/user/payment/purchase/epay',
-                type: 'POST',
-                data: formData,
-                dataType: "json",
-                success: function (data) {
-                    if (data.ret === 1) {
-                        $('#success-message').text(data.msg);
-                        $('#success-dialog').modal('show');
-                        window.location.href = data.url;
-                    } else {
-                        $('#fail-message').text(data.msg);
-                        $('#fail-dialog').modal('show');
-                    }
-                },
-                error: function (data) {
-                    $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
-                },
-                complete: function () {
-                    $('#processing-dialog').modal('hide');
-                }
-            });
-        });
-    });
-</script>

--- a/resources/views/tabler/gateway/stripe.tpl
+++ b/resources/views/tabler/gateway/stripe.tpl
@@ -3,7 +3,7 @@
 
 <div class="card-inner">
     <h4>
-        Stripe 银行卡
+        Stripe
     </h4>
     <p class="card-heading"></p>
     <p>可以使用带有

--- a/src/Services/Gateway/Epay.php
+++ b/src/Services/Gateway/Epay.php
@@ -95,7 +95,7 @@ final class Epay extends Base
             'type' => $type,
             'out_trade_no' => $pl->tradeno,
             'notify_url' => $_ENV['baseUrl'] . '/payment/notify/epay',
-            'return_url' => 'https://' . $_ENV['baseUrl'] . '/user/payment/return/epay',
+            'return_url' => $_ENV['baseUrl'] . '/user/payment/return/epay',
             'name' => $pl->tradeno,
             'money' => $price,
             'sitename' => $_ENV['appName'],

--- a/src/Services/Gateway/Epay.php
+++ b/src/Services/Gateway/Epay.php
@@ -15,8 +15,10 @@ use App\Models\Paylist;
 use App\Services\Auth;
 use App\Services\Gateway\Epay\EpayNotify;
 use App\Services\Gateway\Epay\EpaySubmit;
+use App\Services\Gateway\Epay\EpayTool;
 use App\Services\View;
 use Exception;
+use GuzzleHttp\Client;
 use Psr\Http\Message\ResponseInterface;
 use Slim\Http\Response;
 use Slim\Http\ServerRequest;
@@ -25,6 +27,7 @@ use voku\helper\AntiXSS;
 final class Epay extends Base
 {
     protected array $epay = [];
+    private static string $err_msg = '请求支付失败';
 
     public function __construct()
     {
@@ -90,16 +93,37 @@ final class Epay extends Base
             'type' => $type,
             'out_trade_no' => $pl->tradeno,
             'notify_url' => $_ENV['baseUrl'] . '/payment/notify/epay',
-            'return_url' => $_ENV['baseUrl'] . '/user/payment/return/epay',
+            'return_url' => 'https://' . $_SERVER['HTTP_HOST'] . '/user/payment/return/epay',
             'name' => $pl->tradeno,
             'money' => $price,
             'sitename' => $_ENV['appName'],
+            'clientip' => $_SERVER['REMOTE_ADDR'],
         ];
 
         $epaySubmit = new EpaySubmit($this->epay);
-        $html_text = $epaySubmit->buildRequestForm($data);
-
-        return $response->write($html_text);
+        $data['sign'] = $epaySubmit->buildRequestMysign(EpayTool::argSort($data));
+        $data['sign_type'] = $this->epay['sign_type'];
+        $client = new Client();
+        try {
+            $res = $client->request('POST', $this->epay['apiurl'] . 'mapi.php', ['form_params' => $data]);
+            if ($res->getStatusCode() !== 200) {
+                throw new Exception(self::$err_msg);
+            }
+            $resData = json_decode((string) $res->getBody(), true);
+            if ($resData['code'] !== 1 || ! isset($resData['payurl'])) {
+                throw new Exception(self::$err_msg);
+            }
+            return $response->withJson([
+                'ret' => 1,
+                'url' => $resData['payurl'],
+                'msg' => '订单发起成功，正在跳转到支付页面...',
+            ]);
+        } catch (Exception) {
+            return $response->withJson([
+                'ret' => 0,
+                'msg' => self::$err_msg,
+            ]);
+        }
     }
 
     public function notify($request, $response, $args): ResponseInterface


### PR DESCRIPTION
Submit payment via epay API in backend and redirect the user to the payment URL, instead of submitting payment request on the user side.

Read the current URL as the return address, allowing the user to return to the correct location when the website contains multiple domains.

If possible please help to improve frontend by using htmx instead of jQuery, tried without success...