### PR TITLE
fix: coupon type cannot display properly

### DIFF
--- a/src/Models/UserCoupon.php
+++ b/src/Models/UserCoupon.php
@@ -29,7 +29,7 @@ final class UserCoupon extends Model
      */
     public function type(): string
     {
-        return match (json_decode($this->content)) {
+        return match (json_decode($this->content)->type ?? null) {
             'percentage' => '百分比',
             'fixed' => '固定金额',
             default => '未知',


### PR DESCRIPTION
![image](https://github.com/SSPanel-UIM/SSPanel-UIM-Dev/assets/46434255/6e41a3f1-c0ff-4db1-b594-ab0c5776fc14)

ajax returns the following:
`
"content": "{"type":"percentage","value":"15"}"
`
so `json_decode($this->content)` gets the entire array but `type` is expected here