### PR TITLE
feat: balance top-up

### DIFF
--- a/resources/views/tabler/user/money.tpl
+++ b/resources/views/tabler/user/money.tpl
@@ -15,6 +15,11 @@
                 <div class="col-auto">
                     <div class="btn-list">
                         <a href="#" class="btn btn-primary" data-bs-toggle="modal"
+                           data-bs-target="#topup">
+                            <i class="icon ti ti-plus"></i>
+                            余额充值
+                        </a>
+                        <a href="#" class="btn btn-primary" data-bs-toggle="modal"
                            data-bs-target="#apply-giftcard-dialog">
                             <i class="icon ti ti-cash-banknote"></i>
                             兑换礼品卡
@@ -82,6 +87,36 @@
                             hx-post="/user/giftcard" hx-swap="none"
                             hx-vals='js:{ giftcard: document.getElementById("giftcard").value }'>
                         兑换
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal modal-blur fade" id="topup" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">余额充值</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group mb-3 row">
+                        <div class="col">
+                            <input id="topup_amount" type="number" step="0.01" class="form-control"
+                                   placeholder="请输入要充值的金额">
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn me-auto" data-bs-dismiss="modal">取消</button>
+                    <button id="apply-topup" class="btn btn-primary" data-bs-dismiss="modal"
+                            hx-post="/user/order/create" hx-swap="none"
+                            hx-vals='js:{
+                                amount: document.getElementById("topup_amount").value,
+                                type: "topup"
+                            }'>
+                        充值
                     </button>
                 </div>
             </div>

--- a/resources/views/tabler/user/order/create.tpl
+++ b/resources/views/tabler/user/order/create.tpl
@@ -162,6 +162,7 @@
                 type: 'POST',
                 dataType: "json",
                 data: {
+                    type: 'product',
                     coupon: $('#coupon').val(),
                     product_id: {$product->id},
                 },

--- a/resources/views/tabler/user/order/view.tpl
+++ b/resources/views/tabler/user/order/view.tpl
@@ -62,6 +62,7 @@
                     </div>
                 </div>
             </div>
+            {if $order->type === 'topup'}
             <div class="card my-3">
                 <div class="card-header">
                     <h3 class="card-title">商品内容</h3>
@@ -113,6 +114,7 @@
                     </div>
                 </div>
             </div>
+            {/if}
             <div class="card my-3">
                 <div class="card-header">
                     <h3 class="card-title">关联账单</h3>

--- a/src/Command/Cron.php
+++ b/src/Command/Cron.php
@@ -37,6 +37,7 @@ EOL;
         $jobs->processTabpOrderActivation();
         $jobs->processBandwidthOrderActivation();
         $jobs->processTimeOrderActivation();
+        $jobs->processTopupOrderActivation();
 
         // Run user related jobs
         $jobs->expirePaidUserAccount();

--- a/src/Controllers/User/InvoiceController.php
+++ b/src/Controllers/User/InvoiceController.php
@@ -68,11 +68,13 @@ final class InvoiceController extends BaseController
         $invoice->update_time = Tools::toDateTime($invoice->update_time);
         $invoice->pay_time = Tools::toDateTime($invoice->pay_time);
         $invoice_content = json_decode($invoice->content);
+        $invoice_type = $invoice_contenttype ?? 'product';
 
         return $response->write(
             $this->view()
                 ->assign('invoice', $invoice)
                 ->assign('invoice_content', $invoice_content)
+                ->assign('invoice_type', $invoice_type)
                 ->assign('paylist', $paylist)
                 ->assign('payments', Payment::getPaymentsEnabled())
                 ->fetch('user/invoice/view.tpl')

--- a/src/Controllers/User/OrderController.php
+++ b/src/Controllers/User/OrderController.php
@@ -112,7 +112,7 @@ final class OrderController extends BaseController
         );
     }
 
-    public function process(ServerRequest $request, Response $response, array $args): ResponseInterface
+    public function processProductOrder(ServerRequest $request, Response $response, array $args): ResponseInterface
     {
         $coupon_raw = $this->antiXss->xss_clean($request->getParam('coupon'));
         $product_id = $this->antiXss->xss_clean($request->getParam('product_id'));
@@ -244,6 +244,7 @@ final class OrderController extends BaseController
             'content_id' => 0,
             'name' => $product->name,
             'price' => $product->price,
+            'type' => 'product',
         ];
 
         if ($coupon_raw !== '') {
@@ -281,6 +282,71 @@ final class OrderController extends BaseController
             'msg' => '成功创建订单，正在跳转账单页面',
             'invoice_id' => $invoice->id,
         ]);
+    }
+
+    public function processTopupOrder(ServerRequest $request, Response $response, array $args): ResponseInterface
+    {
+        $amount = $this->antiXss->xss_clean($request->getParam('amount'));
+
+        $amount = is_numeric($amount) ? (float) $amount : null;
+        if ($amount === null || $amount <= 0 || Tools::getDecimalPlaces($amount) > 2) {
+            return $response->withJson([
+                'ret' => 0,
+                'msg' => '充值金额无效',
+            ]);
+        }
+
+        $order = new Order();
+        $order->user_id = $this->user->id;
+        $order->product_id = 0;
+        $order->product_type = 'topup';
+        $order->product_name = '余额充值';
+        $order->product_content = json_encode(['amount' => $amount]);
+        $order->coupon = '';
+        $order->price = $amount;
+        $order->status = 'pending_payment';
+        $order->create_time = time();
+        $order->update_time = time();
+        $order->save();
+
+        $invoice_content = [];
+
+        $invoice_content[] = [
+            'content_id' => 0,
+            'name' => '余额充值',
+            'price' => $amount,
+            'type' => 'topup',
+        ];
+
+        $invoice = new Invoice();
+        $invoice->user_id = $this->user->id;
+        $invoice->order_id = $order->id;
+        $invoice->content = json_encode($invoice_content);
+        $invoice->price = $amount;
+        $invoice->status = 'unpaid';
+        $invoice->create_time = time();
+        $invoice->update_time = time();
+        $invoice->pay_time = 0;
+        $invoice->save();
+
+        return $response->withHeader('HX-Redirect', '/user/invoice/'.$invoice->id.'/view')->withJson([
+            'ret' => 1,
+            'msg' => '成功创建订单，正在跳转账单页面',
+            'invoice_id' => $invoice->id,
+        ]);
+    }
+
+    public function process(ServerRequest $request, Response $response, array $args): ResponseInterface
+    {
+        $type = $this->antiXss->xss_clean($request->getParam('type'));
+        return match ($type) {
+            'product' => $this->processProductOrder($request, $response, $args),
+            'topup' => $this->processTopupOrder($request, $response, $args),
+            default => $response->withJson([
+                'ret' => 0,
+                'msg' => '未知订单类型',
+            ]),
+        };
     }
 
     public function ajax(ServerRequest $request, Response $response, array $args): ResponseInterface

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -50,6 +50,7 @@ final class Order extends Model
             'tabp' => '时间流量包',
             'time' => '时间包',
             'bandwidth' => '流量包',
+            'topup' => '充值',
             default => '其他',
         };
     }

--- a/src/Utils/Tools.php
+++ b/src/Utils/Tools.php
@@ -344,4 +344,18 @@ final class Tools
 
         return true;
     }
+
+    /**
+     * 判断小数点位数
+     *
+     * @param float $float
+     *
+     * @return int
+     */
+
+    public static function getDecimalPlaces(float $float): int
+    {
+        $parts = explode('.', (string) $float);
+        return isset($parts[1]) ? strlen($parts[1]) : 0;
+    }
 }


### PR DESCRIPTION
Allow users to top up the balance. #2392

A new type `topup` is added to Order Model. The type will be checked and passed to the invoice when processing the order. `processProductOrder` and `processTopupOrder` are used in `OrderController` to deal with different types of orders.

Because the invoice has no `type` field so it is stored in the content. It is troublesome to judge the invoice type based on the content, which causes the issue that users can top up with balance. This needs to be checked.

As the same as product packs, the top-up order will be activated in Cron; however, it is strange that users must wait for the top-up to be activated. It would be better if top-up orders could be activated in real time.

The entire process works fine after simple testing.

Known issues:
- [ ] Users can top-up by balance
- [ ] Add `type` to invoice
- [ ] Real-time activation