### PR TITLE
feat: filter nodes by regex in Clash configuration

### DIFF
--- a/src/Services/Subscribe/Clash.php
+++ b/src/Services/Subscribe/Clash.php
@@ -182,6 +182,11 @@ final class Clash extends Base
                 $clash_group_config['proxy-groups'][$index]['proxies'][] = $node_raw->name;
             }
         }
+        foreach ($clash_group_indexes as $index) {
+            if (isset($clash_group_config['proxy-groups'][$index]['filter'])) {
+                unset($clash_group_config['proxy-groups'][$index]['filter']);
+            }
+        }
 
         $clash_nodes = [
             'proxies' => $nodes,

--- a/src/Services/Subscribe/Clash.php
+++ b/src/Services/Subscribe/Clash.php
@@ -173,6 +173,12 @@ final class Clash extends Base
             $nodes[] = $node;
 
             foreach ($clash_group_indexes as $index) {
+                if (isset($clash_group_config['proxy-groups'][$index]['filter'])) {
+                    // 通过正则表达式过滤节点
+                    if (! preg_match($clash_group_config['proxy-groups'][$index]['filter'], $node_raw->name)) {
+                        continue;
+                    }
+                }
                 $clash_group_config['proxy-groups'][$index]['proxies'][] = $node_raw->name;
             }
         }


### PR DESCRIPTION
Nodes can be filtered using regular expression by adding `filter` to proxy-groups items in `appprofile.php`. Currently, this function is only added to Clash configuration.

I remember that the SSP used to have this function, but I don’t know why it has disappeared now.